### PR TITLE
Counting buffers and cache as available memory.

### DIFF
--- a/rpimonitor/default.conf
+++ b/rpimonitor/default.conf
@@ -186,6 +186,13 @@ dynamic.14.regexp=(.*)
 dynamic.14.postprocess=
 dynamic.14.rrd=
 
+dynamic.15.name=memory_available
+dynamic.15.source=/usr/bin/free -mk
+dynamic.15.regexp=^-\/\+ buffers\/cache:\s+\d+\s+(\d+)
+dynamic.15.postprocess=$1/1024
+dynamic.15.rrd=GAUGE
+
+
 ########################################################################
 # Web interface configuration
 # 
@@ -334,8 +341,8 @@ web.status.1.content.4.line.1="CPU Temperature: <b>"+data.soc_temp+"&deg;C</b>"
 
 web.status.1.content.5.name=Memory
 web.status.1.content.5.icon=memory.png
-web.status.1.content.5.line.1="Used: <b>" + KMG(data.memory_total-data.memory_free,'M') + "</b> (<b>" + Percent(data.memory_total-data.memory_free,data.memory_total,'M') + "</b>) Free: <b>" + KMG(data.memory_free,'M') + "</b> Total: <b>" + KMG(data.memory_total,'M') + "</b>"
-web.status.1.content.5.line.2=ProgressBar(data.memory_total-data.memory_free,data.memory_total)
+web.status.1.content.5.line.1="Used: <b>" + KMG(data.memory_total-data.memory_available,'M') + "</b> (<b>" + Percent(data.memory_total-data.memory_available,data.memory_total,'M') + "</b>) Available: <b>" + KMG(data.memory_available,'M') + "</b> Total: <b>" + KMG(data.memory_total,'M') + "</b>"
+web.status.1.content.5.line.2=ProgressBar(data.memory_total-data.memory_available,data.memory_total)
 
 web.status.1.content.6.name=Swap
 web.status.1.content.6.icon=swap.png
@@ -403,7 +410,11 @@ web.statistics.1.content.5.ds_graph_options.swap_used.color="#7777FF"
 
 web.statistics.1.content.6.name=Memory
 web.statistics.1.content.6.graph.1=memory_free
+web.statistics.1.content.6.graph.2=memory_available
 web.statistics.1.content.6.ds_graph_options.memory_free.label=Free Memory (MB)
+web.statistics.1.content.6.ds_graph_options.memory_free.color="#FF7777"
+web.statistics.1.content.6.ds_graph_options.memory_available.label=Available Memory (MB)
+web.statistics.1.content.6.ds_graph_options.memory_available.color="#7777FF"
 
 web.statistics.1.content.7.name=Uptime
 web.statistics.1.content.7.graph.1=uptime


### PR DESCRIPTION
This is a patch to have a more useful measure of memory availability. See [Linux ate my RAM](http://www.linuxatemyram.com/) for details.
