### PR TITLE
Update default.conf to avoid peaks in network graph

### DIFF
--- a/rpimonitor/default.conf
+++ b/rpimonitor/default.conf
@@ -159,14 +159,14 @@ dynamic.9.rrd=GAUGE
 dynamic.10.name=net_received
 dynamic.10.source=/sys/class/net/eth0/statistics/rx_bytes
 dynamic.10.regexp=(.*)
-dynamic.10.postprocess=$1*-1
-dynamic.10.rrd=DERIVE
+dynamic.10.postprocess=
+dynamic.10.rrd=COUNTER
 
 dynamic.11.name=net_send
 dynamic.11.source=/sys/class/net/eth0/statistics/tx_bytes
 dynamic.11.regexp=(.*)
 dynamic.11.postprocess=
-dynamic.11.rrd=DERIVE
+dynamic.11.rrd=COUNTER
 
 dynamic.12.name=soc_temp
 dynamic.12.source=/sys/devices/virtual/thermal/thermal_zone0/temp


### PR DESCRIPTION
On every range overflow of the 32bit network counter there were peaks in network graph for the up and download speed. Setting the RRD to COUNTER fixes this.
It's necessary to delete the RRDs for "net_send" and "net_received" to renew the RRD-Databases during next restart of RPi-Monitor.
For more description see: https://github.com/XavierBerger/RPi-Monitor/issues/19#issuecomment-25920937
