### PR TITLE
Modified disk statistics to calculate the correct sizes.

### DIFF
--- a/rpimonitor/template/raspbian.conf
+++ b/rpimonitor/template/raspbian.conf
@@ -141,7 +141,7 @@ dynamic.5.rrd=GAUGE
 
 dynamic.6.name=sdcard_root_used
 dynamic.6.source=df /
-dynamic.6.regexp=\S+\s+\d+\s+(\d+).*\/boot$
+dynamic.6.regexp=\S+\s+\d+\s+(\d+).*\/$
 dynamic.6.postprocess=$1/1024
 dynamic.6.rrd=GAUGE
 


### PR DESCRIPTION
Statements like 'df -t <fs-type>' will only work when the user has
actually chosen that fs-type, while 'df <mountpoint>' will always work.
Also the regex statements will probably only work on a Raspberry Pi
Foundation provided image, while the current one also works when
installed through f.e. raspbian-ua-netinst.
