### PR TITLE
Add SystemD restart instructions for Interactive Config

### DIFF
--- a/rpimonitor/rpimonitord
+++ b/rpimonitor/rpimonitord
@@ -1008,7 +1008,7 @@ sub PrintConfiguration
   print " add anew file into /etc/rpimonitor/.\n";
   print " <Note the some text require a manual update>\n";
   print " Once the configuration will be apply, restart RPi-Monitor with the\n";
-  print " command: /etc/init.d/rpimonitor restart\n";
+  print " command: /etc/init.d/rpimonitor restart or systemctl restart rpimonitord\n";
 }
 
 sub Run


### PR DESCRIPTION
Interactive Config Helper gives command for SysV init.d restart but was missing SystemD systemctl instructions.