### PR TITLE
Pull available mem from /proc/meminfo

### DIFF
--- a/rpimonitor/template/memory_arch.conf
+++ b/rpimonitor/template/memory_arch.conf
@@ -18,8 +18,8 @@ dynamic.9.postprocess=$1/1024
 dynamic.9.rrd=GAUGE
 
 dynamic.15.name=memory_available
-dynamic.15.source=/usr/bin/free -mk
-dynamic.15.regexp=^Mem:\s+\d+\s+\d+\s+\d+\s+\d+\s+\d+\s+(\d+)
+dynamic.15.source=/proc/meminfo
+dynamic.15.regexp=MemAvailable:\s+(\d+)
 dynamic.15.postprocess=$1/1024
 dynamic.15.rrd=GAUGE
 


### PR DESCRIPTION
Arch /proc/meminfo MemAvailable: is the same as /usr/bin/free -k. (On arch, /usr/bin/free -mk throws an error: "free: Multiple unit options doesn't make sense." /usr/bin/free -k displays mem in kb, but is the same as meminfo.)