### PR TITLE
Fix spelling and grammar in about addon

### DIFF
--- a/rpimonitor/web/addons/about/about.html
+++ b/rpimonitor/web/addons/about/about.html
@@ -10,22 +10,22 @@
     <h3 class="panel-title">About addons</h3>
   </div>
   <div class="panel-body">
-    <b>Addon</b> is design to let you add more functionnality to 
-    <b>RPi-Monitor</b>.<br>
+    <b>Addons</b> are designed to let you add more functionality to <b>RPi-Monitor</b>.
     <br>
-    The realease of <b>RPi-Monitor</b> provides the following addons:<br>
+    <br>
+    This release of <b>RPi-Monitor</b> provides the following addons:<br>
     <ul>
-      <li><b>about</b> - this addons</li>
-      <li><b>custom</b> - custom addons using <code>&lt;iframe&gt;</code> to display external html page</li>
-      <li><b>example</b> - expamle of addons showing how to develop and addons fully integrated to <b>RPi-Monitor</b></li>
+      <li><b>about</b> - This addon</li>
+      <li><b>custom</b> - Custom addon using <code>&lt;iframe&gt;</code> to display external html page</li>
+      <li><b>example</b> - Example of addons showing how to develop addons that are fully integrated with <b>RPi-Monitor</b></li>
       <li><b>shellinabox</b> - Allow ssh access to your computer through your browser</li>
       <li><b>top3</b> - Show the top 3 processes using cpu and rpimonitord cpu usage</li>
     </ul>
     <br>
-    Addons are configured into <code>/etc/rpimonitor/data.conf</code>. You can customise
-    <b>RPi-Monitor</b> configuration to add or remove addons.<br>
+    Addons are configured through <code>/etc/rpimonitor/data.conf</code>. You can customize the <b>RPi-Monitor</b> configuration to add or remove addons.
     <br>
-    Refer to manage and/or comments in configuration file to see in detail how to use addons.
+    <br>
+    Refer to comments in configuration file to see in detail how to manage and use addons.
   </div>
 </body>
 </html>


### PR DESCRIPTION
Make several small fixes to the spelling and grammar of the about addon page. Also fix some of the formating of the page's content.