### PR TITLE
adding /dev/random entropy pool monitoring

### DIFF
--- a/rpimonitor/template/entropy.conf
+++ b/rpimonitor/template/entropy.conf
@@ -1,0 +1,16 @@
+########################################################################
+# Extract /dev/random entropy pool size information
+#  Page: 1
+#  Information               Status     Statistics
+#  - entropy available       - no       - yes
+#######################################################################
+
+dynamic.15.name=entropy_pool
+dynamic.15.source=/proc/sys/kernel/random/entropy_avail
+dynamic.15.regexp=(.*)
+dynamic.15.postprocess=$1
+dynamic.15.rrd=GAUGE
+
+web.statistics.1.content.9.name=Entropy Pool
+web.statistics.1.content.9.graph.1=entropy_pool
+web.statistics.1.content.9.ds_graph_options.entropy_pool.label=Entropy Pool size (Bits)

--- a/rpimonitor/template/raspbian.conf
+++ b/rpimonitor/template/raspbian.conf
@@ -364,5 +364,5 @@ include=/etc/rpimonitor/template/network.conf
 #include=/etc/rpimonitor/template/services.conf
 #include=/etc/rpimonitor/template/wlan.conf
 #include=/etc/rpimonitor/template/dht11.conf
-
+#include=/etc/rpimonitor/template/entropy.conf
 


### PR DESCRIPTION
following the enhancement request, here are the update for the kernel entropy pool monitoring
if entropy pool is empty it may slow down the system, it may be a security concern.