### PR TITLE
Deal with NanoPi NEO 2 with Debian

### DIFF
--- a/src/etc/rpimonitor/template/version.conf
+++ b/src/etc/rpimonitor/template/version.conf
@@ -26,7 +26,7 @@ static.3.postprocess=
 
 static.4.name=processor
 static.4.source=/proc/cpuinfo
-static.4.regexp=(?:Processor|model name)\s+: (.*)
+static.4.regexp=(?:Processor|model name|Hardware)\s+: (.*)
 static.4.postprocess=
 
 dynamic.1.name=upgrade


### PR DESCRIPTION
Hardware: [NanoPi NEO 2](http://wiki.friendlyarm.com/wiki/index.php/NanoPi_NEO2)
Software: Debian Jessie

`cat /proc/cpuinfo`

```
processor	: 0
BogoMIPS	: 48.00
Features	: fp asimd evtstrm aes pmull sha1 sha2 crc32 cpuid
CPU implementer	: 0x41
CPU architecture: 8
CPU variant	: 0x0
CPU part	: 0xd03
CPU revision	: 4

processor	: 1
BogoMIPS	: 48.00
Features	: fp asimd evtstrm aes pmull sha1 sha2 crc32 cpuid
CPU implementer	: 0x41
CPU architecture: 8
CPU variant	: 0x0
CPU part	: 0xd03
CPU revision	: 4

processor	: 2
BogoMIPS	: 48.00
Features	: fp asimd evtstrm aes pmull sha1 sha2 crc32 cpuid
CPU implementer	: 0x41
CPU architecture: 8
CPU variant	: 0x0
CPU part	: 0xd03
CPU revision	: 4

processor	: 3
BogoMIPS	: 48.00
Features	: fp asimd evtstrm aes pmull sha1 sha2 crc32 cpuid
CPU implementer	: 0x41
CPU architecture: 8
CPU variant	: 0x0
CPU part	: 0xd03
CPU revision	: 4

Hardware	: Allwinnersun50iw2Family
Revision	: 0000
Serial		: 0000000000000000
```

<img width="409" alt="screen shot 2017-07-11 at 02 04 47" src="https://user-images.githubusercontent.com/150648/28032529-6971b736-6570-11e7-8a6f-19efdc92cbd3.png">
