### PR TITLE
Correct file path for symlink for stat folder (fixes #202)

### DIFF
--- a/src/etc/rpimonitor/daemon.conf
+++ b/src/etc/rpimonitor/daemon.conf
@@ -23,7 +23,7 @@
 #  daemon.noserver=1
 #    Define that rpimonitor shouldn't start web server (default:0)
 #    Note: A symbolic link from /var/lib/rpimonitor/stat to
-#          /usr/share/rpimonitor/stat may be required
+#          /usr/share/rpimonitor/web/stat may be required.
 #daemon.noserver=1
 # 
 #  daemon.addr=0.0.0.0


### PR DESCRIPTION
The symlink must be created to the web directory not root, I only found out about by looking into the access.log to see why the requests for stat/*.rrd failed.

Fixes #202