### PR TITLE
Mispellings corrected

### DIFF
--- a/docs/source/12_custom_installation.rst
+++ b/docs/source/12_custom_installation.rst
@@ -120,7 +120,7 @@ All the detail are gathered in `DockerHub <https://hub.docker.com/r/michaelmikli
 Yocto
 -----
 
-``meta-rpiexperiences`` is availabale on `github <https://github.com/XavierBerger/meta-rpiexperiences>`_ 
+``meta-rpiexperiences`` is available on `github <https://github.com/XavierBerger/meta-rpiexperiences>`_ 
 gathering the recipes to add **RPi-Monitor** and all its dependencies to your project.
 `meta-rpiexperiences <http://layers.openembedded.org/layerindex/branch/master/layer/meta-rpiexperiences/>`_  
 and `rpimonitor <http://layers.openembedded.org/layerindex/recipe/52439/>`_ are referenced on

--- a/docs/source/13_execution.rst
+++ b/docs/source/13_execution.rst
@@ -92,7 +92,7 @@ how to customize ``rpimonitord``.
 
 snmp-agent
 ----------
-``rpimonotord-snmp`` is the snmp agent provided by **RPi-Monitor**. This agent
+``rpimonitord-snmp`` is the snmp agent provided by **RPi-Monitor**. This agent
 allow ``snmpd`` to access to data exctracted by ``rpimonitord``.
 
 .. seealso:: See `configuration <20_index.html>`_ chapter for details or `usage <30_index.html>`_ chapter for examples.

--- a/docs/source/14_faq.rst
+++ b/docs/source/14_faq.rst
@@ -145,7 +145,7 @@ I've some issue with my installation or customization of **RPi-Monitor** and I w
 
 |
 
-Some data are not extracting correctly at boot but when I restart ``rpimonotord`` everything becomes OK until I reboot. How can I fix thi issue?
+Some data are not extracting correctly at boot but when I restart ``rpimonitord`` everything becomes OK until I reboot. How can I fix thi issue?
 
   If you reach such situation, you certainly configure your source using a 
   command whitout the full path. For example ``gettemp.sh`` instead of 

--- a/docs/source/24_web.rst
+++ b/docs/source/24_web.rst
@@ -58,7 +58,7 @@ web.page.icon=<icon location relative to webroot>
 
 web.page.menutitle=<menu title>
   ``<menu title>`` javascript code defining the text displayed into
-  RPi-Monotor title bar. This code can use status information with
+  RPi-Monitor title bar. This code can use status information with
   the keyword ``data`` including the ``data.hostname`` available natively
 
 web.page.pagetitle=<page title>

--- a/docs/source/27_configuration_templates.rst
+++ b/docs/source/27_configuration_templates.rst
@@ -5,7 +5,7 @@ Configuration templates
 
 **RPi-Monitor** comes with example files showing the capabilities of some features 
 and functions available in status page. 
-These files are installed into ``/etc/rpimonotor/templates/``.
+These files are installed into ``/etc/rpimonitor/templates/``.
 To see how a specific file is behaving, you can include this file into your 
 configuration file using the ``include``. 
 


### PR DESCRIPTION
Replace 'Monotor', 'availabale'