### PR TITLE
Override default Listen queue size of 5

### DIFF
--- a/src/usr/bin/rpimonitord
+++ b/src/usr/bin/rpimonitord
@@ -572,6 +572,7 @@ sub Run
 
   # Create the server
   $this->{'server'} = new HTTP::Daemon     ( ReuseAddr => 1,
+                                             Listen => SOMAXCONN,
                                              LocalAddr => $configuration->{'daemon'}->{'addr'},
                                              LocalPort => $configuration->{'daemon'}->{'port'})
     or die "Web server not started because of error: $!\n";


### PR DESCRIPTION
Define it to the SOMAXCONN system limit (e.g. 128):
```
perl -MSocket -le 'print SOMAXCONN' 
128
```