### PR TITLE
Update init.d script

### DIFF
--- a/src/etc/init.d/rpimonitor
+++ b/src/etc/init.d/rpimonitor
@@ -1,8 +1,8 @@
 #!/bin/sh
 ### BEGIN INIT INFO
 # Provides:          rpimonitor
-# Required-Start:    $remote_fs $syslog
-# Required-Stop:     $remote_fs $syslog
+# Required-Start:    $remote_fs $syslog $network
+# Required-Stop:     $remote_fs $syslog $network
 # Default-Start:     2 3 4 5
 # Default-Stop:      0 1 6
 # X-Interactive:     true


### PR DESCRIPTION
I think service needs $network to start, otherwise someone can't monitor via web. Without this change I need to restart service after each reboot.