### PR TITLE
Update 11_installation.rst

### DIFF
--- a/docs/source/11_installation.rst
+++ b/docs/source/11_installation.rst
@@ -22,8 +22,7 @@ Execute the following command to add **RPi-Monitor** into your list of repositor
 
 ::
 
-  sudo wget https://goo.gl/vewCLL -O /etc/apt/sources.list.d/rpimonitor.list
-
+  echo "deb https://www.giteduberger.fr rpimonitor/" | sudo tee /etc/apt/sources.list.d/rpimonitor.list
 
 
 To install **RPi-Monitor**, execute the following command:


### PR DESCRIPTION
Existing file for /etc/apt/sources.list.d/rpimonitor.list pointed to "http://giteduberger.fr"  and pulled from a goo.gl URL which was trés sketch.   Updated to a line that creates a file that points the sources file on "https://www.giteduberger.fr" which works (: